### PR TITLE
Jules wip 14729405525326539972

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.gson) // Added Gson dependency
     implementation(libs.androidx.work.runtime.ktx) // Added WorkManager dependency
+    implementation(libs.androidx.datastore.preferences) // Added DataStore dependency
+    implementation(libs.coil.compose) // Added Coil compose dependency
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.inline)

--- a/app/src/main/java/com/plantastic/com/PlantasticMain.kt
+++ b/app/src/main/java/com/plantastic/com/PlantasticMain.kt
@@ -27,4 +27,13 @@ object Destinations {
     const val ONBOARDING = "onboarding"
     const val MAIN = "main"
     const val ADD_NOTIFICATION = "add_notification" // New destination
+
+    // Profile Screen items
+    const val PRIVACY_POLICY = "privacy_policy"
+    const val TERMS_AND_CONDITIONS = "terms_and_conditions"
+    const val LICENSES = "licenses"
+    const val RATE_THE_APP = "rate_the_app"
+    const val STATISTICS = "statistics"
+    const val EDIT_PROFILE = "edit_profile"
+    // const val PROFILE = "profile" // Not needed here as ProfileScreen is part of MainScreen's NavGraph
 }

--- a/app/src/main/java/com/plantastic/com/data/ThemeSetting.kt
+++ b/app/src/main/java/com/plantastic/com/data/ThemeSetting.kt
@@ -1,0 +1,5 @@
+package com.plantastic.com.data
+
+enum class ThemeSetting {
+    DYNAMIC, DARK, LIGHT
+}

--- a/app/src/main/java/com/plantastic/com/data/ThemeSettingsManager.kt
+++ b/app/src/main/java/com/plantastic/com/data/ThemeSettingsManager.kt
@@ -1,0 +1,75 @@
+package com.plantastic.com.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.plantastic.com.data.ThemeSetting // Corrected import for ThemeSetting
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+// preferencesDataStore extension defined at the top level
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+class ThemeSettingsManager(private val context: Context) {
+    private val themeKey = stringPreferencesKey("theme_preference")
+
+    // Profile Data Keys
+    private val userNameKey = stringPreferencesKey("user_name")
+    private val userEmailKey = stringPreferencesKey("user_email")
+    private val avatarUriKey = stringPreferencesKey("avatar_uri")
+
+    val themeSettingFlow: Flow<ThemeSetting> = context.dataStore.data
+        .map { preferences ->
+            val themeName = preferences[themeKey] ?: ThemeSetting.LIGHT.name
+            try {
+                ThemeSetting.valueOf(themeName)
+            } catch (e: IllegalArgumentException) {
+                // Handle unknown theme name, default to LIGHT
+                ThemeSetting.LIGHT
+            }
+        }
+
+    suspend fun setTheme(theme: ThemeSetting) {
+        context.dataStore.edit { settings ->
+            settings[themeKey] = theme.name
+        }
+    }
+
+    // Profile Data Flows
+    val userNameFlow: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[userNameKey] ?: ""
+        }
+
+    val userEmailFlow: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[userEmailKey] ?: ""
+        }
+
+    val avatarUriFlow: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[avatarUriKey] ?: ""
+        }
+
+    // Profile Data Setters
+    suspend fun setUserName(name: String) {
+        context.dataStore.edit { settings ->
+            settings[userNameKey] = name
+        }
+    }
+
+    suspend fun setUserEmail(email: String) {
+        context.dataStore.edit { settings ->
+            settings[userEmailKey] = email
+        }
+    }
+
+    suspend fun setAvatarUri(uri: String) {
+        context.dataStore.edit { settings ->
+            settings[avatarUriKey] = uri
+        }
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/EditProfileScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/EditProfileScreen.kt
@@ -41,7 +41,7 @@ import android.net.Uri
 import android.util.Log
 import coil.compose.AsyncImage
 import com.plantastic.com.R // Assuming R class is in this package
-import androidx.compose.material.icons.filled.PersonPin // For avatar placeholder change. Will be replaced by AsyncImage.
+import androidx.compose.foundation.Image
 
 @Composable
 fun EditProfileScreen(
@@ -93,16 +93,26 @@ fun EditProfileScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            AsyncImage(
-                model = if (currentAvatarUri.isEmpty()) painterResource(id = R.drawable.ic_launcher_foreground) else Uri.parse(currentAvatarUri),
-                contentDescription = "User Avatar",
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop,
-                placeholder = painterResource(id = R.drawable.ic_launcher_foreground), // Default placeholder
-                error = painterResource(id = R.drawable.ic_launcher_foreground) // Error placeholder
-            )
+            if (currentAvatarUri.isEmpty()) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                    contentDescription = "Default Avatar",
+                    modifier = Modifier
+                        .size(120.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                AsyncImage(
+                    model = Uri.parse(currentAvatarUri),
+                    contentDescription = "User Avatar",
+                    modifier = Modifier
+                        .size(120.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop,
+                    error = painterResource(id = R.drawable.ic_launcher_foreground)
+                )
+            }
             Button(onClick = { imagePickerLauncher.launch("image/*") }) {
                 Text("Change Avatar")
             }

--- a/app/src/main/java/com/plantastic/com/screens/EditProfileScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/EditProfileScreen.kt
@@ -7,23 +7,73 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+// import androidx.compose.runtime.setValue // Not needed directly if using ViewModel states
+// import androidx.compose.runtime.mutableStateOf // Not needed for name/email if from ViewModel
+// import androidx.compose.runtime.remember // Not needed for name/email if from ViewModel
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import coil.compose.AsyncImage
+import com.plantastic.com.R // Assuming R class is in this package
+import androidx.compose.material.icons.filled.PersonPin // For avatar placeholder change. Will be replaced by AsyncImage.
 
 @Composable
-fun EditProfileScreen() {
-    var name by remember { mutableStateOf("") }
-    var email by remember { mutableStateOf("") }
+fun EditProfileScreen(
+    viewModel: EditProfileViewModel = viewModel(
+        factory = EditProfileViewModelFactory(LocalContext.current.applicationContext as Application)
+    )
+) {
+    val name by viewModel.name.collectAsState()
+    val email by viewModel.email.collectAsState()
+    val currentAvatarUri by viewModel.avatarUri.collectAsState() // Renamed for clarity
+
+    val context = LocalContext.current
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let {
+            val contentResolver = context.contentResolver
+            try {
+                // Take persistable URI permission
+                val takeFlags: Int = Intent.FLAG_GRANT_READ_URI_PERMISSION
+                contentResolver.takePersistableUriPermission(it, takeFlags)
+                viewModel.updateAvatarUri(it.toString())
+            } catch (e: SecurityException) {
+                Log.e("AvatarPicker", "Failed to take persistable URI permission for $it", e)
+                // Optionally, inform the user e.g. via a Toast or a Snackbar
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.loadProfile()
+    }
 
     Column(
         modifier = Modifier
@@ -34,27 +84,40 @@ fun EditProfileScreen() {
     ) {
         Text(
             text = "Edit Profile",
-            style = MaterialTheme.typography.headlineMedium
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(bottom = 16.dp) // Added some bottom padding for separation
         )
 
-        Spacer(modifier = Modifier.height(8.dp)) // Extra space after title
-
-        Text(
-            text = "Avatar Picker (Placeholder)",
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(vertical = 8.dp)
-        )
+        // Avatar Picker Section
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            AsyncImage(
+                model = if (currentAvatarUri.isEmpty()) painterResource(id = R.drawable.ic_launcher_foreground) else Uri.parse(currentAvatarUri),
+                contentDescription = "User Avatar",
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop,
+                placeholder = painterResource(id = R.drawable.ic_launcher_foreground), // Default placeholder
+                error = painterResource(id = R.drawable.ic_launcher_foreground) // Error placeholder
+            )
+            Button(onClick = { imagePickerLauncher.launch("image/*") }) {
+                Text("Change Avatar")
+            }
+        }
 
         OutlinedTextField(
             value = name,
-            onValueChange = { name = it },
+            onValueChange = { viewModel.updateName(it) },
             label = { Text("Name") },
             modifier = Modifier.fillMaxWidth()
         )
 
         OutlinedTextField(
             value = email,
-            onValueChange = { email = it },
+            onValueChange = { viewModel.updateEmail(it) },
             label = { Text("Email") },
             modifier = Modifier.fillMaxWidth()
         )
@@ -62,12 +125,20 @@ fun EditProfileScreen() {
         Spacer(modifier = Modifier.weight(1f)) // Pushes the button to the bottom if content is short
 
         Button(
-            onClick = {
-                // Handle save action later
-            },
+            onClick = { viewModel.saveProfile() },
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Save")
         }
+    }
+}
+
+class EditProfileViewModelFactory(private val application: Application) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(EditProfileViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return EditProfileViewModel(application) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
     }
 }

--- a/app/src/main/java/com/plantastic/com/screens/EditProfileScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/EditProfileScreen.kt
@@ -1,0 +1,73 @@
+package com.plantastic.com.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EditProfileScreen() {
+    var name by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Edit Profile",
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        Spacer(modifier = Modifier.height(8.dp)) // Extra space after title
+
+        Text(
+            text = "Avatar Picker (Placeholder)",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Name") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Email") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.weight(1f)) // Pushes the button to the bottom if content is short
+
+        Button(
+            onClick = {
+                // Handle save action later
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Save")
+        }
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/EditProfileViewModel.kt
+++ b/app/src/main/java/com/plantastic/com/screens/EditProfileViewModel.kt
@@ -1,0 +1,56 @@
+package com.plantastic.com.screens
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.plantastic.com.data.ThemeSettingsManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class EditProfileViewModel(application: Application) : ViewModel() {
+
+    private val themeSettingsManager = ThemeSettingsManager(application)
+
+    private val _name = MutableStateFlow("")
+    val name: StateFlow<String> = _name.asStateFlow()
+
+    private val _email = MutableStateFlow("")
+    val email: StateFlow<String> = _email.asStateFlow()
+
+    private val _avatarUri = MutableStateFlow("")
+    val avatarUri: StateFlow<String> = _avatarUri.asStateFlow()
+
+    fun loadProfile() {
+        viewModelScope.launch {
+            _name.value = themeSettingsManager.userNameFlow.first()
+            _email.value = themeSettingsManager.userEmailFlow.first()
+            _avatarUri.value = themeSettingsManager.avatarUriFlow.first()
+        }
+    }
+
+    fun updateName(newName: String) {
+        _name.value = newName
+    }
+
+    fun updateEmail(newEmail: String) {
+        _email.value = newEmail
+    }
+
+    fun updateAvatarUri(newUri: String) {
+        _avatarUri.value = newUri
+        // In a real app, this might trigger an image picker,
+        // and the result would update the URI.
+        // For now, we directly set it.
+    }
+
+    fun saveProfile() {
+        viewModelScope.launch {
+            themeSettingsManager.setUserName(_name.value)
+            themeSettingsManager.setUserEmail(_email.value)
+            themeSettingsManager.setAvatarUri(_avatarUri.value)
+        }
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/LicensesScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/LicensesScreen.kt
@@ -1,0 +1,31 @@
+package com.plantastic.com.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LicensesScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Licenses",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Licenses information will be available here in a future update.",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/MainScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/MainScreen.kt
@@ -24,9 +24,19 @@ fun MainScreen() {
         ) {
             composable(BottomNavItem.Home.route) { HomeScreen() }
             composable(BottomNavItem.Garden.route) { GardenScreen() }
-            composable(BottomNavItem.Notifications.route) { NotificationsScreen(navController) } // Pass NavController
-            composable(BottomNavItem.Profile.route) { ProfileScreen() }
-            composable(com.plantastic.com.Destinations.ADD_NOTIFICATION) { AddNotificationScreen(navController) } // Add new route
+            composable(BottomNavItem.Notifications.route) { NotificationsScreen(navController) }
+            composable(BottomNavItem.Profile.route) { ProfileScreen(navController) } // Pass NavController
+            composable(com.plantastic.com.Destinations.ADD_NOTIFICATION) { AddNotificationScreen(navController) }
+
+            // New Profile sub-screens
+            composable(com.plantastic.com.Destinations.PRIVACY_POLICY) { PrivacyPolicyScreen() }
+            composable(com.plantastic.com.Destinations.TERMS_AND_CONDITIONS) { TermsAndConditionsScreen() }
+            composable(com.plantastic.com.Destinations.LICENSES) { LicensesScreen() }
+            composable(com.plantastic.com.Destinations.RATE_THE_APP) { RateTheAppScreen() }
+            composable(com.plantastic.com.Destinations.STATISTICS) { StatisticsScreen() }
+            composable(com.plantastic.com.Destinations.EDIT_PROFILE) { EditProfileScreen() }
+            // Onboarding is typically handled by the main app NavHost, but if a profile item needs to re-trigger it:
+            composable(com.plantastic.com.Destinations.ONBOARDING) { OnboardingScreen(navController) } // Assuming OnboardingScreen can take a NavController from this graph too
         }
     }
 }

--- a/app/src/main/java/com/plantastic/com/screens/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/PrivacyPolicyScreen.kt
@@ -1,0 +1,31 @@
+package com.plantastic.com.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PrivacyPolicyScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Privacy Policy",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "This is the Privacy Policy screen. The actual content will be added here.",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/ProfileScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import com.plantastic.com.R // Assuming R class for drawables
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.LaunchedEffect
 
 // Enum ThemeSetting was moved to data package
 
@@ -52,16 +54,26 @@ fun UserProfileHeader(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        AsyncImage(
-            model = if (avatarUri.isEmpty()) painterResource(id = R.drawable.ic_launcher_foreground) else Uri.parse(avatarUri),
-            contentDescription = "User Avatar",
-            modifier = Modifier
-                .size(80.dp)
-                .clip(CircleShape),
-            contentScale = ContentScale.Crop,
-            placeholder = painterResource(id = R.drawable.ic_launcher_foreground), // Default placeholder
-            error = painterResource(id = R.drawable.ic_launcher_foreground) // Error placeholder
-        )
+        if (avatarUri.isEmpty()) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                contentDescription = "Default Avatar",
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            AsyncImage(
+                model = Uri.parse(avatarUri),
+                contentDescription = "User Avatar",
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop,
+                error = painterResource(id = R.drawable.ic_launcher_foreground)
+            )
+        }
         Text(
             text = if (name.isNotEmpty()) name else "User Name",
             style = MaterialTheme.typography.titleLarge
@@ -109,6 +121,10 @@ fun ProfileScreen(
     val name by viewModel.name.collectAsState()
     val email by viewModel.email.collectAsState()
     val avatarUri by viewModel.avatarUri.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadUserProfile()
+    }
 
     // Define menu items as a list of pairs: (Text, Destination Route)
     val menuItems = listOf(

--- a/app/src/main/java/com/plantastic/com/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/ProfileScreen.kt
@@ -1,13 +1,86 @@
 package com.plantastic.com.screens
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.runtime.Composable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.RadioButton
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.navigation.NavController
+import com.plantastic.com.Destinations
+import androidx.compose.foundation.clickable
+
+// 1. Define Theme Options
+enum class ThemeSetting {
+    DYNAMIC, DARK, LIGHT
+}
 
 @Composable
-fun ProfileScreen() {
-    Text("👤 Profile", style = MaterialTheme.typography.headlineMedium, modifier = Modifier.padding(16.dp))
+fun ThemeSwitcherSection() {
+    val currentTheme = remember { mutableStateOf(ThemeSetting.LIGHT) }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text("Select Theme", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(bottom = 8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            ThemeSetting.values().forEach { theme ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(
+                        selected = currentTheme.value == theme,
+                        onClick = { currentTheme.value = theme }
+                    )
+                    Text(theme.name, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ProfileScreen(navController: NavController) { // Added NavController
+    // Define menu items as a list of pairs: (Text, Destination Route)
+    val menuItems = listOf(
+        "Onboarding" to Destinations.ONBOARDING,
+        "Privacy Policy" to Destinations.PRIVACY_POLICY,
+        "Terms and Conditions" to Destinations.TERMS_AND_CONDITIONS,
+        "Licenses" to Destinations.LICENSES,
+        "Rate the App" to Destinations.RATE_THE_APP,
+        "Statistics" to Destinations.STATISTICS,
+        "Edit Profile" to Destinations.EDIT_PROFILE
+    )
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text("👤 Profile", style = MaterialTheme.typography.headlineMedium, modifier = Modifier.padding(bottom = 16.dp))
+
+        ThemeSwitcherSection()
+
+        Spacer(modifier = Modifier.height(16.dp)) // Add some space before the list
+
+        LazyColumn {
+            items(menuItems) { (title, route) ->
+                Text(
+                    text = title,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { navController.navigate(route) }
+                        .padding(vertical = 12.dp) // Increased padding for better touch target
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/plantastic/com/screens/ProfileViewModel.kt
+++ b/app/src/main/java/com/plantastic/com/screens/ProfileViewModel.kt
@@ -1,8 +1,18 @@
 package com.plantastic.com.screens
 
 import android.app.Application
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import com.plantastic.com.data.ThemeSetting
 import com.plantastic.com.data.ThemeSettingsManager
 import kotlinx.coroutines.flow.Flow
@@ -39,7 +49,7 @@ class ProfileViewModel(application: Application) : ViewModel() {
         loadUserProfile()
     }
 
-    private fun loadUserProfile() {
+    fun loadUserProfile() {
         viewModelScope.launch {
             _name.value = themeSettingsManager.userNameFlow.first()
             _email.value = themeSettingsManager.userEmailFlow.first()

--- a/app/src/main/java/com/plantastic/com/screens/ProfileViewModel.kt
+++ b/app/src/main/java/com/plantastic/com/screens/ProfileViewModel.kt
@@ -1,0 +1,49 @@
+package com.plantastic.com.screens
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.plantastic.com.data.ThemeSetting
+import com.plantastic.com.data.ThemeSettingsManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class ProfileViewModel(application: Application) : ViewModel() {
+
+    private val themeSettingsManager = ThemeSettingsManager(application)
+
+    // Theme settings
+    val themeSettingFlow: Flow<ThemeSetting> = themeSettingsManager.themeSettingFlow
+
+    fun setTheme(theme: ThemeSetting) {
+        viewModelScope.launch {
+            themeSettingsManager.setTheme(theme)
+        }
+    }
+
+    // User profile data
+    private val _name = MutableStateFlow("")
+    val name: StateFlow<String> = _name.asStateFlow()
+
+    private val _email = MutableStateFlow("")
+    val email: StateFlow<String> = _email.asStateFlow()
+
+    private val _avatarUri = MutableStateFlow("")
+    val avatarUri: StateFlow<String> = _avatarUri.asStateFlow()
+
+    init {
+        loadUserProfile()
+    }
+
+    private fun loadUserProfile() {
+        viewModelScope.launch {
+            _name.value = themeSettingsManager.userNameFlow.first()
+            _email.value = themeSettingsManager.userEmailFlow.first()
+            _avatarUri.value = themeSettingsManager.avatarUriFlow.first()
+        }
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/RateTheAppScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/RateTheAppScreen.kt
@@ -1,0 +1,31 @@
+package com.plantastic.com.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RateTheAppScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Rate the App",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Functionality to rate the app will be implemented here.",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/StatisticsScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/StatisticsScreen.kt
@@ -1,0 +1,41 @@
+package com.plantastic.com.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun StatisticsScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Statistics",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Total Waterings: 0",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Successful Repottings: 0",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Average Watering Interval: N/A",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/app/src/main/java/com/plantastic/com/screens/StatisticsScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/StatisticsScreen.kt
@@ -8,11 +8,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
-fun StatisticsScreen() {
+fun StatisticsScreen(viewModel: StatisticsViewModel = viewModel()) {
+    val totalWaterings by viewModel.totalWaterings.collectAsState()
+    val successfulRepottings by viewModel.successfulRepottings.collectAsState()
+    val averageWateringInterval by viewModel.averageWateringInterval.collectAsState()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -24,17 +31,17 @@ fun StatisticsScreen() {
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = "Total Waterings: 0",
+            text = "Total Waterings: $totalWaterings",
             style = MaterialTheme.typography.bodyLarge
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = "Successful Repottings: 0",
+            text = "Successful Repottings: $successfulRepottings",
             style = MaterialTheme.typography.bodyLarge
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = "Average Watering Interval: N/A",
+            text = "Average Watering Interval: $averageWateringInterval",
             style = MaterialTheme.typography.bodyLarge
         )
     }

--- a/app/src/main/java/com/plantastic/com/screens/StatisticsViewModel.kt
+++ b/app/src/main/java/com/plantastic/com/screens/StatisticsViewModel.kt
@@ -1,0 +1,21 @@
+package com.plantastic.com.screens
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class StatisticsViewModel : ViewModel() {
+
+    private val _totalWaterings = MutableStateFlow(123)
+    val totalWaterings: StateFlow<Int> = _totalWaterings.asStateFlow()
+
+    private val _successfulRepottings = MutableStateFlow(15)
+    val successfulRepottings: StateFlow<Int> = _successfulRepottings.asStateFlow()
+
+    private val _averageWateringInterval = MutableStateFlow("5 days")
+    val averageWateringInterval: StateFlow<String> = _averageWateringInterval.asStateFlow()
+
+    // In a real app, you might have functions to load/refresh this data.
+    // For this subtask, dummy data is initialized directly.
+}

--- a/app/src/main/java/com/plantastic/com/screens/TermsAndConditionsScreen.kt
+++ b/app/src/main/java/com/plantastic/com/screens/TermsAndConditionsScreen.kt
@@ -1,0 +1,31 @@
+package com.plantastic.com.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TermsAndConditionsScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Terms and Conditions",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "This is the Terms and Conditions screen. The actual content will be added here.",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ nav_version = "2.9.0"
 gson = "2.10.1" # Added Gson version
 workManager = "2.9.0" # Added WorkManager version
 mockitoCore = "5.12.0" # Added Mockito version
+datastore = "1.1.1" # Added DataStore version
+coil = "2.6.0" # Added Coil version
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -36,6 +38,8 @@ androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx"
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "workManager" } # Added WorkManager testing library
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockitoCore" } # Added Mockito library
 mockito-inline = { group = "org.mockito", name = "mockito-inline", version.ref = "mockitoCore" } # Added Mockito inline for final classes/methods if needed
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" } # Added DataStore library
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" } # Added Coil library
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
feat: Implement comprehensive profile screen and settings
This commit delivers a fully functional Profile screen with several key features:

1.  **User Profile Display:**
    - The Profile screen now shows your avatar (loaded with Coil), name, and email. This data is fetched from local DataStore.

2.  **Theme Switching:**
    - You can select between Dynamic, Dark, and Light themes via a switcher in the Profile screen.
    - The selected theme is persisted using Jetpack DataStore (`ThemeSettingsManager`).
    - The application's UI theme dynamically updates based on this preference.

3.  **Edit Profile Functionality:**
    - The Edit Profile screen allows you to:
        - Pick an avatar image from your device gallery. The chosen image is displayed (using Coil) and its URI is persisted.
        - Edit your name and email.
    - All changes are saved to DataStore.
    - `EditProfileViewModel` manages the state and data operations for this screen.

4.  **Statistics Screen:**
    - The Statistics screen displays placeholder data for key metrics (Total Waterings, Successful Repottings, Average Watering Interval) via `StatisticsViewModel`.

5.  **Navigation and Structure:**
    - All profile-related screens (Privacy Policy, Terms & Conditions, Licenses, Rate App, Onboarding, Statistics, Edit Profile) are navigable from the main Profile screen.
    - ViewModels (`ProfileViewModel`, `EditProfileViewModel`, `StatisticsViewModel`) have been implemented to manage UI logic and state.
    - Placeholder screens for Licenses, Rate App, Privacy Policy, and Terms & Conditions are in place.

This work completes the core requirements for the Profile screen and its associated functionalities as outlined in the issue.